### PR TITLE
fix PS and SNES D-pad button order after 07258d4ecdf612f42e19e58634f3b781b861584d

### DIFF
--- a/addons/game.controller.ps/resources/layout.xml
+++ b/addons/game.controller.ps/resources/layout.xml
@@ -8,8 +8,8 @@
 		<button name="start" type="digital" label="30005"/>
 		<button name="select" type="digital" label="30006"/>
 		<button name="up" type="digital" label="30007" direction="up"/>
-		<button name="down" type="digital" label="30008" direction="down"/>
 		<button name="right" type="digital" label="30009" direction="right"/>
+		<button name="down" type="digital" label="30008" direction="down"/>
 		<button name="left" type="digital" label="30010" direction="left"/>
 		<button name="l3" type="digital" label="30011"/>
 		<button name="r3" type="digital" label="30012"/>

--- a/addons/game.controller.snes/resources/layout.xml
+++ b/addons/game.controller.snes/resources/layout.xml
@@ -8,8 +8,8 @@
     <button name="start" type="digital" label="30005"/>
     <button name="select" type="digital" label="30006"/>
     <button name="up" type="digital" label="30007" direction="up"/>
-    <button name="down" type="digital" label="30008" direction="down"/>
     <button name="right" type="digital" label="30009" direction="right"/>
+    <button name="down" type="digital" label="30008" direction="down"/>
     <button name="left" type="digital" label="30010" direction="left"/>
   </category>
   <category name="shoulder">


### PR DESCRIPTION
I noticed that 07258d4ecdf612f42e19e58634f3b781b861584d doesn't contain the adjustments for the D-Pad order for the PS and SNES controller layouts.