### PR TITLE
Controller topology schema

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ The data in this repo is stored in the format of Kodi add-ons. Add-ons consist o
 
 3. **icon.png** - the thumbnail used in the GUI
 
-4. **layout.xml** - the button layout
+4. **layout.xml** - the button layout and topology
 
 6. **strings.po** - The names of the buttons
 
@@ -59,7 +59,7 @@ Opaque image of the controller. This should be the transparent image against [ba
 
 ## layout.xml
 
-This file describes the button layout. The root `<layout>` tag contains the following attributes:
+This file describes the button layout and topology (how controllers connect to each other). The root `<layout>` tag contains the following attributes:
 
 1. Path to layout.png
 2. Path to mask.png
@@ -247,6 +247,20 @@ menu |
 power | Power Macintosh power key
 euro | Some European keyboards
 undo | Atari keyboard has Undo
+
+### Topology
+
+The topology is given by the `<physicaltopology>` tag. This allows for hubs and daisy-chaining. It describes the physical connections possible for this controller.
+
+Controller topologies have the following properties:
+
+1. Whether the controller provides input - true for controllers, false for hubs
+2. List of ports on the device
+
+A port contains:
+
+1. Port ID (used in Kodi's Game API)
+2. List of controllers that the port accepts
 
 ## strings.po
 

--- a/addons/game.controller.saturn.multitap/addon.xml
+++ b/addons/game.controller.saturn.multitap/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.saturn.multitap"
         name="Sega Saturn 6 Player Adaptor"
-        version="1.0.5"
+        version="1.0.6"
         provider-name="Team Kodi">
     <requires>
     </requires>

--- a/addons/game.controller.saturn.multitap/resources/layout.xml
+++ b/addons/game.controller.saturn.multitap/resources/layout.xml
@@ -4,26 +4,68 @@
 		<port id="1">
 			<accepts controller="game.controller.saturn"/>
 			<accepts controller="game.controller.saturn.3d"/>
+			<accepts controller="game.controller.saturn.arcade.racer"/>
+			<accepts controller="game.controller.saturn.mission.stick"/>
+			<accepts controller="game.controller.saturn.mission.sticks"/>
+			<accepts controller="game.controller.saturn.mouse"/>
+			<accepts controller="game.controller.saturn.multitap"/>
+			<accepts controller="game.controller.saturn.twin.stick"/>
+			<accepts controller="game.controller.saturn.virtua.gun"/>
 		</port>
 		<port id="2">
 			<accepts controller="game.controller.saturn"/>
 			<accepts controller="game.controller.saturn.3d"/>
+			<accepts controller="game.controller.saturn.arcade.racer"/>
+			<accepts controller="game.controller.saturn.mission.stick"/>
+			<accepts controller="game.controller.saturn.mission.sticks"/>
+			<accepts controller="game.controller.saturn.mouse"/>
+			<accepts controller="game.controller.saturn.multitap"/>
+			<accepts controller="game.controller.saturn.twin.stick"/>
+			<accepts controller="game.controller.saturn.virtua.gun"/>
 		</port>
 		<port id="3">
 			<accepts controller="game.controller.saturn"/>
 			<accepts controller="game.controller.saturn.3d"/>
+			<accepts controller="game.controller.saturn.arcade.racer"/>
+			<accepts controller="game.controller.saturn.mission.stick"/>
+			<accepts controller="game.controller.saturn.mission.sticks"/>
+			<accepts controller="game.controller.saturn.mouse"/>
+			<accepts controller="game.controller.saturn.multitap"/>
+			<accepts controller="game.controller.saturn.twin.stick"/>
+			<accepts controller="game.controller.saturn.virtua.gun"/>
 		</port>
 		<port id="4">
 			<accepts controller="game.controller.saturn"/>
 			<accepts controller="game.controller.saturn.3d"/>
+			<accepts controller="game.controller.saturn.arcade.racer"/>
+			<accepts controller="game.controller.saturn.mission.stick"/>
+			<accepts controller="game.controller.saturn.mission.sticks"/>
+			<accepts controller="game.controller.saturn.mouse"/>
+			<accepts controller="game.controller.saturn.multitap"/>
+			<accepts controller="game.controller.saturn.twin.stick"/>
+			<accepts controller="game.controller.saturn.virtua.gun"/>
 		</port>
 		<port id="5">
 			<accepts controller="game.controller.saturn"/>
 			<accepts controller="game.controller.saturn.3d"/>
+			<accepts controller="game.controller.saturn.arcade.racer"/>
+			<accepts controller="game.controller.saturn.mission.stick"/>
+			<accepts controller="game.controller.saturn.mission.sticks"/>
+			<accepts controller="game.controller.saturn.mouse"/>
+			<accepts controller="game.controller.saturn.multitap"/>
+			<accepts controller="game.controller.saturn.twin.stick"/>
+			<accepts controller="game.controller.saturn.virtua.gun"/>
 		</port>
 		<port id="6">
 			<accepts controller="game.controller.saturn"/>
 			<accepts controller="game.controller.saturn.3d"/>
+			<accepts controller="game.controller.saturn.arcade.racer"/>
+			<accepts controller="game.controller.saturn.mission.stick"/>
+			<accepts controller="game.controller.saturn.mission.sticks"/>
+			<accepts controller="game.controller.saturn.mouse"/>
+			<accepts controller="game.controller.saturn.multitap"/>
+			<accepts controller="game.controller.saturn.twin.stick"/>
+			<accepts controller="game.controller.saturn.virtua.gun"/>
 		</port>
 	</physicaltopology>
 </layout>


### PR DESCRIPTION
This adds a schema for the physical controller topology introduced in https://github.com/xbmc/xbmc/pull/13499.

For information about the schema of the logical topology, see https://github.com/kodi-game/game.libretro/pull/31.