### PR TITLE
Atari 2600: Change analog stick to directional buttons

### DIFF
--- a/addons/game.controller.atari.2600/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.atari.2600/resources/language/resource.language.en_gb/strings.po
@@ -25,37 +25,49 @@ msgid "Fire"
 msgstr ""
 
 msgctxt "#30002"
-msgid "Joystick"
+msgid "Up"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Select"
+msgid "Right"
 msgstr ""
 
 msgctxt "#30004"
-msgid "Reset"
+msgid "Down"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Color"
+msgid "Left"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Black/White"
+msgid "Select"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Left Difficulty A"
+msgid "Reset"
 msgstr ""
 
 msgctxt "#30008"
-msgid "Left Difficulty B"
+msgid "Color"
 msgstr ""
 
 msgctxt "#30009"
-msgid "Right Difficulty A"
+msgid "Black/White"
 msgstr ""
 
 msgctxt "#30010"
+msgid "Left Difficulty A"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Left Difficulty B"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Right Difficulty A"
+msgstr ""
+
+msgctxt "#30013"
 msgid "Right Difficulty B"
 msgstr ""

--- a/addons/game.controller.atari.2600/resources/layout.xml
+++ b/addons/game.controller.atari.2600/resources/layout.xml
@@ -2,16 +2,19 @@
 <layout label="30000" image="layout.png" mask="mask.png">
   <category name="face" label="35074">
     <button name="fire" type="digital" label="30001"/>
-    <analogstick name="joystick" label="30002"/>
+    <button name="up" type="digital" label="30002"/>
+    <button name="right" type="digital" label="30003"/>
+    <button name="down" type="digital" label="30004"/>
+    <button name="left" type="digital" label="30005"/>
   </category>
   <category name="hardware" label="35107">
-    <button name="select" type="digital" label="30003"/>
-    <button name="reset" type="digital" label="30004"/>
-    <button name="color" type="digital" label="30005"/>
-    <button name="bw" type="digital" label="30006"/>
-    <button name="leftdifficultya" type="digital" label="30007"/>
-    <button name="leftdifficultyb" type="digital" label="30008"/>
-    <button name="rightdifficultya" type="digital" label="30009"/>
-    <button name="rightdifficultyb" type="digital" label="30010"/>
+    <button name="select" type="digital" label="30006"/>
+    <button name="reset" type="digital" label="30007"/>
+    <button name="color" type="digital" label="30008"/>
+    <button name="bw" type="digital" label="30009"/>
+    <button name="leftdifficultya" type="digital" label="30010"/>
+    <button name="leftdifficultyb" type="digital" label="30011"/>
+    <button name="rightdifficultya" type="digital" label="30012"/>
+    <button name="rightdifficultyb" type="digital" label="30013"/>
   </category>
 </layout>


### PR DESCRIPTION
Fixes broken directional buttons in Atari 2600 games